### PR TITLE
Use export default for better interoperability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ function minmaxC(A: [number, number, number, number]): minMax {
  * @param {String} d SVG path for which their bounding box will be computed.
  * @returns {BBox}
  */
-export = function svgPathBbox(d: string): BBox {
+export default function svgPathBbox(d: string): BBox {
   const min = [Infinity, Infinity],
     max = [-Infinity, -Infinity];
   svgPath(d)


### PR DESCRIPTION
Even with `skipLibCheck` to true, I get this warning in 1.1.0:
`node_modules/svg-path-bbox/src/index.ts:89:1 - error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.`

PS: I'm really surprise TS is even read this file for typechecking only, that totally unnecessary. Another solution could be to not publish this file.